### PR TITLE
Update README to show the default supported stateName

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ export default combineReducers({
 })
 ```
 
+Note: You can change the `stateName` (ex: `offline`) by passing `stateName` to additional configuration.
+
 ### Step 2: Add the offlineMiddleware
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Get up and running in 4 easy steps:
 
 ### Step 1: Add the redux-offline-queue reducer to your combine reducers
 
-Either import the `{ reducer as offlineQueue }` from `redux-offline-queue` and add it to the `combineReducers` or require it like so (whatever floats your boat):
+Either import the `{ reducer as offline }` from `redux-offline-queue` and add it to the `combineReducers` or require it like so (whatever floats your boat):
 
 ```javascript
 import { combineReducers } from 'redux'
 
 export default combineReducers({
-    offlineQueue: require('redux-offline-queue').reducer,
+    offline: require('redux-offline-queue').reducer,
     yourOtherReducer: require('~App/yourOtherReducer').reducer,
 })
 ```


### PR DESCRIPTION
Reasons:
I ran into an error in my project following the docs with this example. The default config is `offline`, not `offlineQueue`. 