### PR TITLE
Merge meta on actions

### DIFF
--- a/src/offlineActions.js
+++ b/src/offlineActions.js
@@ -16,7 +16,7 @@ const appendOfflineMeta = (creator) => {
     return {
       ...creatorResult,
       meta: {
-        ...creatorResult.meta
+        ...creatorResult.meta,
         queueIfOffline: true,
       },
     }

--- a/src/offlineActions.js
+++ b/src/offlineActions.js
@@ -16,6 +16,7 @@ const appendOfflineMeta = (creator) => {
     return {
       ...creatorResult,
       meta: {
+        ...creatorResult.meta
         queueIfOffline: true,
       },
     }

--- a/src/offlineMiddleware.js
+++ b/src/offlineMiddleware.js
@@ -32,6 +32,7 @@ function fireQueuedActions(queue, dispatch) {
       ...actionInQueue,
       consume: true,
       meta: {
+        ...actionInQueue.meta,
         queueIfOffline: false,
       },
     })


### PR DESCRIPTION
I'm using meta for passing some data, but with redux-offline-queue currently its override all meta field in the JSON.

Just a PR to merge meta with the current data